### PR TITLE
Update rubocop version

### DIFF
--- a/__fake_gem.gemspec
+++ b/__fake_gem.gemspec
@@ -4,5 +4,5 @@ Gem::Specification.new do |s|
     s.authors = ['Anthony Sottile']
     s.summary = 'A fake mirror gem for rubocop'
     s.description = 'A fake mirror gem for rubocop'
-    s.add_dependency 'rubocop', '0.30.0'
+    s.add_dependency 'rubocop', '0.32.1'
 end


### PR DESCRIPTION
Use latest released version

I wasn't entirely certain if this was the right/best way to update the hook's version, considering it's living inside an rbenv in a homedir, but I guessed this might be correct.

Happy to change it if this is the wrong direction.
